### PR TITLE
fix 2 bugs

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -19,6 +19,8 @@ export default class TypeScriptCompiler extends BabelCompiler {
       cacheDeps,
     );
 
+    babelOptions.plugins = babelOptions.plugins || [];
+
     babelOptions.plugins.unshift(
       inputFile.require('@babel/plugin-transform-typescript'),
     );
@@ -52,7 +54,9 @@ export default class TypeScriptCompiler extends BabelCompiler {
 
   processOneFileForTarget(inputFile) {
     const result = super.processOneFileForTarget(inputFile);
-    result.path = result.path.replace(/\.ts(x)?/, '.js$1');
-    return result;
+    if (result) {
+      result.path = result.path.replace(/\.ts(x)?/, '.js$1');
+      return result;
+    }
   }
 }


### PR DESCRIPTION
there are 2 modifications: 

1.  In order to avoid error: 'read unshift of undefined', I just add one line below before use babelOptions.plugins. Thus there is no need to create an empty .babelrc file.
```
        babelOptions.plugins = babelOptions.plugins || [];
```

2.  super.processOneFileForTarget(inputFile) could return null if error encountered. So I add a condition there:
```
        if (result) {
            result.path = result.path.replace(/\.ts(x)?/, '.js$1');
            return result;
        }
```